### PR TITLE
Use the standard zlib LICENSE formatting

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,17 @@
 Copyright (c) 2017 Solra Bizna
 
-This software is provided 'as-is', without any express or implied warranty. In no event will the author be held liable for any damages arising from the use of this software.
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the author be held liable for any damages
+arising from the use of this software.
 
-Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
 
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.


### PR DESCRIPTION
Only if you are interested I changed the the LICENSE formatting to that of the standard zlib LICENSE for easy of readability.

See: https://www.zlib.net/zlib_license.html

Looking at the github markdown preview it has not changed at all so this would only apply when looking at the file with an editor or a tool like `less(1)`.