### PR TITLE
Fix -Wnon-virtual-dtor warning

### DIFF
--- a/byuuML.cc
+++ b/byuuML.cc
@@ -6,6 +6,8 @@
 
 using namespace byuuML;
 
+reader::~reader() {};
+
 namespace {
   class line_getter : std::vector<char> {
     reader& raw_reader;

--- a/byuuML.hh
+++ b/byuuML.hh
@@ -68,6 +68,7 @@ namespace byuuML {
   class reader {
   public:
     // Signal EOF by making begin == end
+    virtual ~reader() = 0;
     virtual void read_more(const char*& begin, const char*& end) = 0;
   };
   class document {


### PR DESCRIPTION
Fixes a `-Wnon-virtual-dtor` warning in byuuML.
```
In file included from byuuML/byuuML.cc:4:
byuuML/byuuML.hh:71:9: warning: 'byuuML::reader' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
  class reader {
        ^
1 warning generated.
```