### PR TITLE
Support c++11

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ I don't claim to have originated or designed the byuuML format, or any copyright
 
 (If you are only interested in technical details about the byuuML file format, you want to read [`FORMAT.md`](FORMAT.md).)
 
-This library is written in C++14. Bindings to other languages, including C, are not provided.
+This library is written in C++11. Bindings to other languages, including C, are not provided.
 
-Add `byuuML.cc` to your project, add the directory containing `byuuML.hh` to your include path (if needed), and make sure your compiler is set to comply with C++14 or higher.
+Add `byuuML.cc` to your project, add the directory containing `byuuML.hh` to your include path (if needed), and make sure your compiler is set to comply with C++11 or higher.
 
 Files that must parse or process a byuuML document should `#include "byuuML.hh"`.
 

--- a/byuuML.cc
+++ b/byuuML.cc
@@ -140,7 +140,7 @@ namespace {
     }
     return ret;
   }
-  constexpr bool is_valid_name_char(char c) {
+  bool is_valid_name_char(char c) {
     if(c >= 'A' && c <= 'Z') return true;
     else if(c >= 'a' && c <= 'z') return true;
     else if(c >= '0' && c <= '9') return true;
@@ -337,14 +337,14 @@ document::document(reader& raw_reader, size_t max_depth) {
     // this code is a little weird because it has to do everything "backwards"
     // TODO: this memory layout isn't ideal, see if we can find a way to "un-
     // reverse" the ordering of child-groups of nodes at the same level
-    node_buffer = std::make_unique<node[]>(num_nodes);
+    node_buffer = std::unique_ptr<node[]>(new node[num_nodes]());
     struct cook_state {
       std::list<node_being_parsed>::const_reverse_iterator current_node,
         current_end;
       node::index current_index, last_index;
     };
     std::unique_ptr<cook_state[]> stack
-      = std::make_unique<cook_state[]>(deepest_child+1);
+      = std::unique_ptr<cook_state[]>(new cook_state[deepest_child+1]());
     stack[0] = cook_state{
       document_nodes.crbegin(),
       document_nodes.crend(),


### PR DESCRIPTION
The jgemu bsnes fork is now complaint with c++11 where it is likely going to stay. It would also be nice if byuuML would also build as c++11 now.

See: https://gitlab.com/jgemu/bsnes/-/commit/3d01169b0061562e315b75bf77ee96574ff41b4a