### PR TITLE
Fix -Wpedantic on older compilers

### DIFF
--- a/byuuML.cc
+++ b/byuuML.cc
@@ -6,7 +6,7 @@
 
 using namespace byuuML;
 
-reader::~reader() {};
+reader::~reader() {}
 
 namespace {
   class line_getter : std::vector<char> {


### PR DESCRIPTION
This fixes a pedantic warning when building using NetBSD's default compiler (GCC 7.5 as of today).

While I'm here, I might as well point that the project description still says C++14 when this is now a C++11 codebase.

Thanks!